### PR TITLE
add README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,10 @@
+This is a collection of interactive jupyter notebooks to showcase
+[MDAnalysis](https://www.mdanalysis.org). To start a notebook server in the
+cloud you can click on the image below.
+
+
+[![Binder](https://mybinder.org/badge.svg)](https://mybinder.org/v2/gh/MDAnalysis/binder-notebook/master?filepath=analysis)
+
+
+Alternatively you can also download this repository and run the notebooks
+locally.


### PR DESCRIPTION
this adds a readme giving a very brief description of the content of this repository.

@orbeckst the binder link I include here only points to the *analysis* folder. This is nice because we only see the notebooks in the final binder server then. The hole installation doesn't show up anymore. We might also rename the folder to *notebooks* then.